### PR TITLE
encrypt_block => encrypted_block

### DIFF
--- a/src/archive_encryptor.py
+++ b/src/archive_encryptor.py
@@ -47,7 +47,7 @@ class ArchiveEncryptor:
                 break
 
             encrypted_block = cipher.encrypt_block(block)
-            hasher.update(encrypt_block)
+            hasher.update(encrypted_block)
             output_strm.write(encrypted_block)
 
         encrypted_block = cipher.encrypt_block(cipher.append_padding(block))


### PR DESCRIPTION
There was a typo in archive_encryptor.py causing the program to crash.