### PR TITLE
Add requirements.txt for pip dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Dependencies
 * pyskein (`pip3 install pyskein`)
 * argon2-cffi (`pip3 install argon2-cffi`)
 
+Install both dependencies by running `pip3 install -r requirements.txt`
+
 Usage
 -----
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+argon2-cffi==16.3.0
+cffi==1.9.1
+pkg-resources==0.0.0
+pycparser==2.17
+pyskein==1.0
+six==1.10.0


### PR DESCRIPTION
Pins the dependency versions to ones known to work with the program.